### PR TITLE
Minor typo in documentation of ansible module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ansible-kcli-modules
 
-Provides access to the latest release of the kcli modules. 
+Provides access to the latest release of the kcli modules.
 
 Include this role in a playbook, and any other plays, roles, and includes will have access to the modules.
 
@@ -16,7 +16,7 @@ The modules are found in the [library folder](./library)
 Use the Galaxy client to install the role:
 
 ```
-$ ansible-galaxy install karmabs.kcli-modules
+$ ansible-galaxy install karmab.kcli-modules
 ```
 
 Once installed, add it to a playbook:


### PR DESCRIPTION
[~]$ ansible-galaxy install karmabs.kcli-modules                                                                                                                                                                  
- downloading role 'kcli-modules', owned by karmabs                                                                                                                                                               
 [WARNING]: - karmabs.kcli-modules was NOT installed successfully: - sorry, karmabs.kcli-modules was not
found on https://galaxy.ansible.com.                                                                    
                                                           
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.                                            
                                                             
[~]$ ansible-galaxy install karmab.kcli-modules --force         
                                                               
- changing role karmab.kcli-modules from master to unspecified
- downloading role 'kcli-modules', owned by karmab          
- downloading role from https://github.com/karmab/ansible-kcli-modules/archive/master.tar.gz
- extracting karmab.kcli-modules to /home/rcarrata/.ansible/roles/karmab.kcli-modules
- karmab.kcli-modules (master) was installed successfully 
