### PR TITLE
Fix typo in kcli_vm.py

### DIFF
--- a/plugins/modules/kcli_vm.py
+++ b/plugins/modules/kcli_vm.py
@@ -79,7 +79,7 @@ def main():
                 config.profiles[profile] = {}
             overrides = module.params['parameters'] if module.params['parameters'] is not None else {}
             meta = config.create_vm(name, profile, overrides=overrides)
-            changed. skipped = True, False
+            changed, skipped = True, False
     else:
         if exists:
             meta = k.delete(name)


### PR DESCRIPTION
This is fixing typo inside kcli_vm. It was conducting to a bug and it was not possible to create vms.

This was the error message:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: cannot access local variable 'changed' where it is not associated with a value
fatal: [127.0.0.1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/aluneau/.ansible/tmp/ansible-tmp-1725024327.8190725-53937-239427512009915/AnsiballZ_kcli_vm.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/aluneau/.ansible/tmp/ansible-tmp-1725024327.8190725-53937-239427512009915/AnsiballZ_kcli_vm.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/aluneau/.ansible/tmp/ansible-tmp-1725024327.8190725-53937-239427512009915/AnsiballZ_kcli_vm.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.karmab.kcli.plugins.modules.kcli_vm', init_globals=dict(_module_fqn='ansible_collections.karmab.kcli.plugins.modules.kcli_vm', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_karmab.kcli.kcli_vm_payload_vjsl8cx_/ansible_karmab.kcli.kcli_vm_payload.zip/ansible_collections/karmab/kcli/plugins/modules/kcli_vm.py\", line 97, in <module>\n  File \"/tmp/ansible_karmab.kcli.kcli_vm_payload_vjsl8cx_/ansible_karmab.kcli.kcli_vm_payload.zip/ansible_collections/karmab/kcli/plugins/modules/kcli_vm.py\", line 82, in main\nUnboundLocalError: cannot access local variable 'changed' where it is not associated with a value\n", "module_stdout": "\u001b[36mDeploying vm tahitibob from profile kvirt...\u001b[0m\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

```

Aftert the fix vm is created as expected 